### PR TITLE
Application Layer -- Equatable

### DIFF
--- a/03_Advisor/lib/3_application/pages/advice/bloc/advicer_event.dart
+++ b/03_Advisor/lib/3_application/pages/advice/bloc/advicer_event.dart
@@ -1,6 +1,9 @@
 part of 'advicer_bloc.dart';
 
 @immutable
-sealed class AdvicerEvent {}
+sealed class AdvicerEvent extends Equatable {
+  @override
+  List<Object?> get props => [];
+}
 
 class AdviceRequestedEvent extends AdvicerEvent {}

--- a/03_Advisor/lib/3_application/pages/advice/bloc/advicer_state.dart
+++ b/03_Advisor/lib/3_application/pages/advice/bloc/advicer_state.dart
@@ -1,7 +1,10 @@
 part of 'advicer_bloc.dart';
 
 @immutable
-sealed class AdvicerState {}
+sealed class AdvicerState extends Equatable {
+  @override
+  List<Object?> get props => [];
+}
 
 class AdvicerInitial extends AdvicerState {}
 
@@ -10,9 +13,13 @@ class AdvicerStateLoading extends AdvicerState {}
 class AdvicerStateLoaded extends AdvicerState {
   final String advice;
   AdvicerStateLoaded({required this.advice});
+  @override
+  List<Object?> get props => [advice];
 }
 
 class AdvicerStateError extends AdvicerState {
   final String message;
   AdvicerStateError({required this.message});
+  @override
+  List<Object?> get props => [message];
 }

--- a/03_Advisor/pubspec.lock
+++ b/03_Advisor/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   fake_async:
     dependency: transitive
     description:

--- a/03_Advisor/pubspec.yaml
+++ b/03_Advisor/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
     sdk: flutter
   provider: ^6.1.1
   flutter_bloc: ^8.1.3
+  equatable: ^2.0.5
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
Being able to compare objects in Dart often involves having to override the == operator as well as hashCode.

Not only is it verbose and tedious, but failure to do so can lead to inefficient code which does not behave as we expect.

By default, == returns true if two objects are the same instance.

Let's say we have the following class: